### PR TITLE
Fix captive portal not redirecting

### DIFF
--- a/ESPAsyncWiFiManager.cpp
+++ b/ESPAsyncWiFiManager.cpp
@@ -442,7 +442,7 @@ boolean  AsyncWiFiManager::startConfigPortal(char const *apName, char const *apP
   scannow= -1 ;
   while (_configPortalTimeout == 0 || millis() < _configPortalStart + _configPortalTimeout) {
     //DNS
-    //dnsServer->processNextRequest();
+    dnsServer->processNextRequest();
 
     //
     //  we should do a scan every so often here


### PR DESCRIPTION
For some reason the code was commented so the DNS server wasn't processing requests.

Needs testing with AsyncDNS library.

Fixes #28 
Fixes #24 