### PR TITLE
#32 + AsyncDNS type update

### DIFF
--- a/ESPAsyncWiFiManager.cpp
+++ b/ESPAsyncWiFiManager.cpp
@@ -115,7 +115,11 @@ void AsyncWiFiManager::setupConfigPortal() {
   DEBUG_WM(WiFi.softAPIP());
 
   /* Setup the DNS server redirecting all the domains to the apIP */
+  #ifdef USE_EADNS
+  dnsServer->setErrorReplyCode(AsyncDNSReplyCode::NoError);
+  #else
   dnsServer->setErrorReplyCode(DNSReplyCode::NoError);
+  #endif
   dnsServer->start(DNS_PORT, "*", WiFi.softAPIP());
 
   setInfo();

--- a/ESPAsyncWiFiManager.cpp
+++ b/ESPAsyncWiFiManager.cpp
@@ -446,8 +446,10 @@ boolean  AsyncWiFiManager::startConfigPortal(char const *apName, char const *apP
   scannow= -1 ;
   while (_configPortalTimeout == 0 || millis() < _configPortalStart + _configPortalTimeout) {
     //DNS
-    //dnsServer->processNextRequest();
-
+    #ifndef USE_EADNS	
+    dnsServer->processNextRequest();
+    #endif
+	
     //
     //  we should do a scan every so often here
     //


### PR DESCRIPTION
Follow up on https://github.com/alanswx/ESPAsyncWiFiManager/pull/32
Async does not need processrequest. As the calls come in it is processed asynchronously. But updating the Async DNS type: https://github.com/devyte/ESPAsyncDNSServer/commit/2921be0674210a8b0667eacc22f156c7178ecdca