### PR TITLE
Fix crash on ESP-32 and add retry functionality

### DIFF
--- a/ESPAsyncWiFiManager.h
+++ b/ESPAsyncWiFiManager.h
@@ -120,8 +120,8 @@ public:
   void          criticalLoop();
   String        infoAsString();
 
-  boolean       autoConnect();
-  boolean       autoConnect(char const *apName, char const *apPassword = NULL);
+  boolean       autoConnect(unsigned long maxConnectRetries = 1, unsigned long retryDelayMs = 1000);
+  boolean       autoConnect(char const *apName, char const *apPassword = NULL, unsigned long maxConnectRetries = 1, unsigned long retryDelayMs = 1000);
 
   //if you want to always start the config portal, without trying to connect first
   boolean       startConfigPortal(char const *apName, char const *apPassword = NULL);
@@ -140,6 +140,10 @@ public:
 
   //sets timeout for which to attempt connecting, usefull if you get a lot of failed connects
   void          setConnectTimeout(unsigned long seconds);
+
+  //wether or not the wifi manager tries to connect to configured access point even when
+  //configuration portal (ESP as access point) is running [default true/on]
+  void          setTryConnectDuringConfigPortal(boolean v);
 
 
   void          setDebugOutput(boolean debug);
@@ -248,6 +252,8 @@ private:
   WiFiResult          *wifiSSIDs;
   wifi_ssid_count_t   wifiSSIDCount;
   boolean             wifiSSIDscan;
+
+  boolean             _tryConnectDuringConfigPortal = true;
 
   void (*_apcallback)(AsyncWiFiManager*) = NULL;
   void (*_savecallback)(void) = NULL;


### PR DESCRIPTION
The crash in https://github.com/alanswx/ESPAsyncWiFiManager/issues/44 was caused by `scanNetworks` returning `-2` (WIFI_SCAN_FAILED) or `-1` (WIFI_SCAN_RUNNING).

The previous code then "allocated" a negative number of array entries to store network information which led to the crash. Negative numbers are now handled separately.

So why did `scanNetworks` even return error codes?

- connection to router could not be established first try (in my case because restarting/reconnecting the ESP32 is too fast for my router)
- while starting the AP mode on ESP32 the STA mode still tried to connect to known SSID
- when the STA mode connects, scanning networks fails with ESP-IDF >3.0.3 (https://github.com/espressif/esp-idf/issues/2497)

To make `scanNetworks` useful again in this scenario, one simply has to call `WiFi.disconnect()` before scanning.

Additionally this commit adds the functionality to call `WiFi.connect()` after scanning when AP is up which means the ESP32 tries to reconnect (activated by default; can be set with `setTryConnectDuringConfigPortal`). This seems to be the only way to connect with my router in case of the aforementioned problem; simply waiting does not work. This reconnection can also be attempted before the configuration portal/access point is created.

Conclusion: In all of my tests `scanNetwork` does not produce an error anymore, possible other errors will be handled without crashing and ESPAsyncWiFiManager now works as expected (i.e. without restarting the ESP) even when the router doesn't recognize the first connection attempt.