### PR TITLE
Faster connection initialization

### DIFF
--- a/ESPAsyncWiFiManager.cpp
+++ b/ESPAsyncWiFiManager.cpp
@@ -207,7 +207,20 @@ boolean AsyncWiFiManager::autoConnect(char const *apName, char const *apPassword
 	  }
 
 	  if(tryNumber + 1 < maxConnectRetries) {
-		  delay(retryDelayMs);
+
+		  // we might connect during the delay
+		  unsigned long restDelayMs = retryDelayMs;
+		  while(restDelayMs != 0) {
+			  if(WiFi.status() == WL_CONNECTED) {
+				  DEBUG_WM(F("IP Address (connected during delay):"));
+				  DEBUG_WM(WiFi.localIP());
+				  return true;
+			  }
+			  unsigned long thisDelay = std::min(restDelayMs, 100ul);
+			  delay(thisDelay);
+			  restDelayMs -= thisDelay;
+		  }
+
 	  }
   }
 


### PR DESCRIPTION
After `connectWifi` the ESP32 might still connect to an access point. Instead of waiting, connecting, disconnecting and re-connecting during the delay, one can actively wait for the connection to happen. This makes connecting faster. 