### PR TITLE
Allow extra options to be added to the root page

### DIFF
--- a/ESPAsyncWiFiManager.cpp
+++ b/ESPAsyncWiFiManager.cpp
@@ -371,8 +371,10 @@ void AsyncWiFiManager::startConfigPortalModeless(char const *apName, char const 
     DEBUG_WM(WiFi.localIP());
     //connected
     // call the callback!
-    _savecallback();
-
+	if ( _savecallback != NULL) {
+	  //todo: check if any custom parameters actually exist, and check if they really changed maybe
+	  _savecallback();
+	}
   }
 
 
@@ -759,6 +761,8 @@ void AsyncWiFiManager::handleWifi(AsyncWebServerRequest *request,boolean scan) {
   shouldscan=true;
   scannow= -1 ;
 
+  DEBUG_WM(F("Handle wifi"));
+
   String page = FPSTR(WFM_HTTP_HEAD);
   page.replace("{v}", "Config ESP");
   page += FPSTR(HTTP_SCRIPT);
@@ -1059,6 +1063,7 @@ request->send ( 204, "text/plain", "");
 }*/
 
 void AsyncWiFiManager::handleNotFound(AsyncWebServerRequest *request) {
+  DEBUG_WM(F("Handle not found"));
   if (captivePortal(request)) { // If captive portal redirect instead of displaying the error page.
     return;
   }

--- a/ESPAsyncWiFiManager.cpp
+++ b/ESPAsyncWiFiManager.cpp
@@ -750,6 +750,7 @@ void AsyncWiFiManager::handleRoot(AsyncWebServerRequest *request) {
   page += "</h1>";
   page += F("<h3>AsyncWiFiManager</h3>");
   page += FPSTR(HTTP_PORTAL_OPTIONS);
+  page += _customOptionsElement;
   page += FPSTR(HTTP_END);
 
   request->send(200, "text/html", page);
@@ -1112,6 +1113,11 @@ void AsyncWiFiManager::setSaveConfigCallback( void (*func)(void) ) {
 //sets a custom element to add to head, like a new style tag
 void AsyncWiFiManager::setCustomHeadElement(const char* element) {
   _customHeadElement = element;
+}
+
+//sets a custom element to add to options page
+void AsyncWiFiManager::setCustomOptionsElement(const char* element) {
+  _customOptionsElement = element;
 }
 
 //if this is true, remove duplicated Access Points - defaut true

--- a/ESPAsyncWiFiManager.h
+++ b/ESPAsyncWiFiManager.h
@@ -167,6 +167,8 @@ public:
   void          setCustomHeadElement(const char* element);
   //if this is true, remove duplicated Access Points - defaut true
   void          setRemoveDuplicateAPs(boolean removeDuplicates);
+  //sets a custom element to add to options page
+  void          setCustomOptionsElement(const char* element);
 
 private:
   AsyncWebServer *server;
@@ -218,6 +220,7 @@ private:
   boolean       _tryWPS                 = false;
 #endif
   const char*   _customHeadElement      = "";
+  const char*   _customOptionsElement   = "";
 
   //String        getEEPROMString(int start, int len);
   //void          setEEPROMString(int start, int len, String string);

--- a/library.json
+++ b/library.json
@@ -9,5 +9,5 @@
   },
   "frameworks": "arduino",
   "platforms": ["espressif8266", "espressif32"],
-  "version": "0.19"
+  "version": "0.20"
 }

--- a/library.json
+++ b/library.json
@@ -1,5 +1,5 @@
 {
-  "name": "ESPAsyncWifiManager",
+  "name": "ESPAsyncWiFiManager",
   "keywords": "wifi, wi-fi",
   "description": "ESP8266 Async WiFi Connection manager with fallback web configuration portal",
   "repository":

--- a/library.json
+++ b/library.json
@@ -9,5 +9,5 @@
   },
   "frameworks": "arduino",
   "platforms": ["espressif8266", "espressif32"],
-  "version": "0.20"
+  "version": "0.21"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP Async WiFi Manager
-version=0.19
+version=0.20
 author=alanswx
 maintainer=alanswx
 sentence=ESP8266 and ESP32 Async WiFi Connection manager with fallback web configuration portal

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP Async WiFi Manager
-version=0.20
+version=0.21
 author=alanswx
 maintainer=alanswx
 sentence=ESP8266 and ESP32 Async WiFi Connection manager with fallback web configuration portal


### PR DESCRIPTION
With this change I can add extra buttons to the root page which can be handled directly by the application. My specific use for these is to allow access to the main web GUI of the application when there is no connection to a router.