### PR TITLE
Disconnect without blanking SSID and password

### DIFF
--- a/ESPAsyncWiFiManager.cpp
+++ b/ESPAsyncWiFiManager.cpp
@@ -487,7 +487,14 @@ boolean  AsyncWiFiManager::startConfigPortal(char const *apName, char const *apP
     {
       DEBUG_WM(F("About to scan()"));
       shouldscan=true;  // since we are modal, we can scan every time
-      WiFi.disconnect(); // we might still be connecting, so that has to stop for scanning
+    #if defined(ESP8266)
+      // we might still be connecting, so that has to stop for scanning
+      ETS_UART_INTR_DISABLE ();
+      wifi_station_disconnect ();
+      ETS_UART_INTR_ENABLE ();
+    #else
+      WiFi.disconnect (false);
+    #endif
       scan();
       if(_tryConnectDuringConfigPortal) WiFi.begin(); // try to reconnect to AP
       scannow= millis() ;

--- a/library.json
+++ b/library.json
@@ -9,5 +9,5 @@
   },
   "frameworks": "arduino",
   "platforms": ["espressif8266", "espressif32"],
-  "version": "0.21"
+  "version": "0.22"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP Async WiFi Manager
-version=0.21
+version=0.22
 author=alanswx
 maintainer=alanswx
 sentence=ESP8266 and ESP32 Async WiFi Connection manager with fallback web configuration portal


### PR DESCRIPTION
This should solve #57. Calling `WiFi.disconnect()` on ESP8266 deletes stored SSID and password. This solution has already been used in other lines: 
- [L571](https://github.com/alanswx/ESPAsyncWiFiManager/blob/master/ESPAsyncWiFiManager.cpp#L571)
- [L585](https://github.com/alanswx/ESPAsyncWiFiManager/blob/master/ESPAsyncWiFiManager.cpp#L585)