### PR TITLE
Avoid config save callback in case of reconnection

### DIFF
--- a/ESPAsyncWiFiManager.cpp
+++ b/ESPAsyncWiFiManager.cpp
@@ -496,12 +496,16 @@ boolean  AsyncWiFiManager::startConfigPortal(char const *apName, char const *apP
       WiFi.disconnect (false);
     #endif
       scan();
-      if(_tryConnectDuringConfigPortal) WiFi.begin(); // try to reconnect to AP
+	  bool connectedDuringConfigPortal = false;
+      if(_tryConnectDuringConfigPortal) {
+		  WiFi.begin(); // try to reconnect to AP
+		  connectedDuringConfigPortal = true;
+	  }
       scannow= millis() ;
     }
 
-	// attempts to reconnect were successful
-	if(WiFi.status() == WL_CONNECTED) {
+	// attempts to reconnect were successful unless just connected using stored values
+	if(!connectedDuringConfigPortal && WiFi.status() == WL_CONNECTED &&) {
 		//connected
 		WiFi.mode(WIFI_STA);
 		//notify that configuration has changed and any optional parameters should be saved

--- a/ESPAsyncWiFiManager.cpp
+++ b/ESPAsyncWiFiManager.cpp
@@ -464,6 +464,7 @@ boolean  AsyncWiFiManager::startConfigPortal(char const *apName, char const *apP
 
   _apName = apName;
   _apPassword = apPassword;
+  bool connectedDuringConfigPortal = false;
 
   //notify we entered AP mode
   if ( _apcallback != NULL) {
@@ -496,7 +497,6 @@ boolean  AsyncWiFiManager::startConfigPortal(char const *apName, char const *apP
       WiFi.disconnect (false);
     #endif
       scan();
-	  bool connectedDuringConfigPortal = false;
       if(_tryConnectDuringConfigPortal) {
 		  WiFi.begin(); // try to reconnect to AP
 		  connectedDuringConfigPortal = true;
@@ -506,11 +506,11 @@ boolean  AsyncWiFiManager::startConfigPortal(char const *apName, char const *apP
 
 	// attempts to reconnect were successful 
 	// configuraton should not be saved when just connected using stored ssid and password
-	if(!connectedDuringConfigPortal && WiFi.status() == WL_CONNECTED &&) {
 		//connected
+	if (WiFi.status () == WL_CONNECTED) {
 		WiFi.mode(WIFI_STA);
 		//notify that configuration has changed and any optional parameters should be saved
-		if ( _savecallback != NULL) {
+		if (!connectedDuringConfigPortal && _savecallback != NULL) {
 			//todo: check if any custom parameters actually exist, and check if they really changed maybe
 			_savecallback();
 		}

--- a/ESPAsyncWiFiManager.cpp
+++ b/ESPAsyncWiFiManager.cpp
@@ -504,7 +504,8 @@ boolean  AsyncWiFiManager::startConfigPortal(char const *apName, char const *apP
       scannow= millis() ;
     }
 
-	// attempts to reconnect were successful unless just connected using stored values
+	// attempts to reconnect were successful 
+	// configuraton should not be saved when just connected using stored ssid and password
 	if(!connectedDuringConfigPortal && WiFi.status() == WL_CONNECTED &&) {
 		//connected
 		WiFi.mode(WIFI_STA);


### PR DESCRIPTION
In case of WiFi is not available during start and it is recovered while config portal is active, using stored values, save config callback should not be called.

If doing so and user has not taken care to initialize text field values to stored ones, configuration gets overwritten with wrong data.

This PR checks if a reconnection with stored ssid and password has happened and disables subsequent callback invocation.