### PR TITLE
Make easier to check if configuration should be saved

### DIFF
--- a/ESPAsyncWiFiManager.cpp
+++ b/ESPAsyncWiFiManager.cpp
@@ -371,12 +371,12 @@ void AsyncWiFiManager::startConfigPortalModeless(char const *apName, char const 
     DEBUG_WM(F("IP Address:"));
     DEBUG_WM(WiFi.localIP());
     //connected
-    // call the callback! // gmag11: Should callback be called here?
-	//_shouldSaveConfig = true;
-	/*if ( _savecallback != NULL) {
+    // call the callback!
+	_shouldSaveConfig = true;
+	if ( _savecallback != NULL) {
 	  //todo: check if any custom parameters actually exist, and check if they really changed maybe
 	  _savecallback();
-	}*/
+	}
   }
 
 

--- a/ESPAsyncWiFiManager.cpp
+++ b/ESPAsyncWiFiManager.cpp
@@ -355,6 +355,7 @@ void AsyncWiFiManager::startConfigPortalModeless(char const *apName, char const 
   _modeless =true;
   _apName = apName;
   _apPassword = apPassword;
+  _shouldSaveConfig = false;
 
   /*
   AJS - do we want this?
@@ -370,11 +371,12 @@ void AsyncWiFiManager::startConfigPortalModeless(char const *apName, char const 
     DEBUG_WM(F("IP Address:"));
     DEBUG_WM(WiFi.localIP());
     //connected
-    // call the callback!
-	if ( _savecallback != NULL) {
+    // call the callback! // gmag11: Should callback be called here?
+	//_shouldSaveConfig = true;
+	/*if ( _savecallback != NULL) {
 	  //todo: check if any custom parameters actually exist, and check if they really changed maybe
 	  _savecallback();
-	}
+	}*/
   }
 
 
@@ -428,6 +430,7 @@ void AsyncWiFiManager::criticalLoop(){
 		// alanswx - should we have a config to decide if we should shut down AP?
 		// WiFi.mode(WIFI_STA);
 		//notify that configuration has changed and any optional parameters should be saved
+		_shouldSaveConfig = true;
 		if ( _savecallback != NULL) {
 		  //todo: check if any custom parameters actually exist, and check if they really changed maybe
 		  _savecallback();
@@ -439,6 +442,7 @@ void AsyncWiFiManager::criticalLoop(){
 	  if (_shouldBreakAfterConfig) {
 		//flag set to exit after config after trying to connect
 		//notify that configuration has changed and any optional parameters should be saved
+		_shouldSaveConfig = true;
 		if ( _savecallback != NULL) {
 		  //todo: check if any custom parameters actually exist, and check if they really changed maybe
 		  _savecallback();
@@ -462,6 +466,7 @@ boolean  AsyncWiFiManager::startConfigPortal(char const *apName, char const *apP
   WiFi.mode(WIFI_AP_STA);
   DEBUG_WM("SET AP STA");
 
+  _shouldSaveConfig = false;
   _apName = apName;
   _apPassword = apPassword;
 
@@ -505,6 +510,7 @@ boolean  AsyncWiFiManager::startConfigPortal(char const *apName, char const *apP
 		//connected
 		WiFi.mode(WIFI_STA);
 		//notify that configuration has changed and any optional parameters should be saved
+		_shouldSaveConfig = true;
 		if ( _savecallback != NULL) {
 			//todo: check if any custom parameters actually exist, and check if they really changed maybe
 			_savecallback();
@@ -533,6 +539,7 @@ boolean  AsyncWiFiManager::startConfigPortal(char const *apName, char const *apP
       }
 
       if (_shouldBreakAfterConfig) {
+		_shouldSaveConfig = true;
         //flag set to exit after config after trying to connect
         //notify that configuration has changed and any optional parameters should be saved
         if ( _savecallback != NULL) {

--- a/ESPAsyncWiFiManager.h
+++ b/ESPAsyncWiFiManager.h
@@ -145,7 +145,6 @@ public:
   //configuration portal (ESP as access point) is running [default true/on]
   void          setTryConnectDuringConfigPortal(boolean v);
 
-
   void          setDebugOutput(boolean debug);
   //defaults to not showing anything under 8% signal quality if called
   void          setMinimumSignalQuality(int quality = 8);
@@ -157,6 +156,10 @@ public:
   void          setAPCallback( void (*func)(AsyncWiFiManager*) );
   //called when settings have been changed and connection was successful
   void          setSaveConfigCallback( void (*func)(void) );
+  //gets condition that signals if configuration should be saved
+  boolean		shouldSaveConfig () {
+	  return _shouldSaveConfig;
+  }
   //adds a custom parameter
   void          addParameter(AsyncWiFiManagerParameter *p);
   //if this is set, it will exit after config, even if connection is unsucessful.
@@ -260,6 +263,7 @@ private:
 
   void (*_apcallback)(AsyncWiFiManager*) = NULL;
   void (*_savecallback)(void) = NULL;
+  boolean _shouldSaveConfig = false;
 
   AsyncWiFiManagerParameter* _params[WIFI_MANAGER_MAX_PARAMS];
 


### PR DESCRIPTION
This implements a flag to let user code to check if configuration has to be saved. This makes possible to work without the need of `_savecallback` implementation