### PR TITLE
Persistent removal of WIFI credentials in STA mode

### DIFF
--- a/ESPAsyncWiFiManager.cpp
+++ b/ESPAsyncWiFiManager.cpp
@@ -687,7 +687,12 @@ String AsyncWiFiManager::getConfigPortalSSID() {
 void AsyncWiFiManager::resetSettings() {
   DEBUG_WM(F("settings invalidated"));
   DEBUG_WM(F("THIS MAY CAUSE AP NOT TO START UP PROPERLY. YOU NEED TO COMMENT IT OUT AFTER ERASING THE DATA."));
-  WiFi.disconnect(true);
+	
+  WiFi.mode(WIFI_AP_STA); // cannot erase if not in STA mode !
+  WiFi.persistent(true);
+  WiFi.disconnect(true,true);
+  WiFi.persistent(false);	
+	
   //delay(200);
 }
 void AsyncWiFiManager::setTimeout(unsigned long seconds) {

--- a/library.json
+++ b/library.json
@@ -9,5 +9,5 @@
   },
   "frameworks": "arduino",
   "platforms": ["espressif8266", "espressif32"],
-  "version": "0.24"
+  "version": "0.25"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP Async WiFi Manager
-version=0.24
+version=0.25
 author=alanswx
 maintainer=alanswx
 sentence=ESP8266 and ESP32 Async WiFi Connection manager with fallback web configuration portal


### PR DESCRIPTION
as discussed in #82, #54 and #65 this should now reset the settings on the ESPs properly (only tested with ESP32 as I only have this one running here...)