### PR TITLE
Build Failure ESPAsyncWiFiManager.cpp:398:51 #89

### DIFF
--- a/src/ESPAsyncWiFiManager.cpp
+++ b/src/ESPAsyncWiFiManager.cpp
@@ -395,7 +395,7 @@ void AsyncWiFiManager::copySSIDInfo(wifi_ssid_count_t n)
         {
           if (cssid == wifiSSIDs[j].SSID)
           {
-            DEBUG_WM(F("DUP AP: ") + wifiSSIDs[j].SSID);
+            DEBUG_WM("DUP AP: " + wifiSSIDs[j].SSID);
             wifiSSIDs[j].duplicate = true; // set dup aps to NULL
           }
         }


### PR DESCRIPTION
diff --git a/src/ESPAsyncWiFiManager.cpp b/src/ESPAsyncWiFiManager.cpp
index 82f08fb..ac6be80 100644
--- a/src/ESPAsyncWiFiManager.cpp
+++ b/src/ESPAsyncWiFiManager.cpp
@@ -395,7 +395,7 @@ void AsyncWiFiManager::copySSIDInfo(wifi_ssid_count_t n)
         {
           if (cssid == wifiSSIDs[j].SSID)
           {
-            DEBUG_WM(F("DUP AP: ") + wifiSSIDs[j].SSID);
+            DEBUG_WM("DUP AP: " + wifiSSIDs[j].SSID);
             wifiSSIDs[j].duplicate = true; // set dup aps to NULL
           }
         }