### PR TITLE
fix not connect to AP when the _tryConnectDuringConfigPortal is not set

### DIFF
--- a/src/ESPAsyncWiFiManager.cpp
+++ b/src/ESPAsyncWiFiManager.cpp
@@ -643,7 +643,7 @@ boolean AsyncWiFiManager::startConfigPortal(char const *apName, char const *apPa
       DEBUG_WM(F("Connecting to new AP"));
 
       // using user-provided _ssid, _pass in place of system-stored ssid and pass
-      if (connectWifi(_ssid, _pass) == WL_CONNECTED)
+      if (_tryConnectDuringConfigPortal and connectWifi(_ssid, _pass) == WL_CONNECTED)
       {
         // connected
         WiFi.mode(WIFI_STA);
@@ -657,7 +657,8 @@ boolean AsyncWiFiManager::startConfigPortal(char const *apName, char const *apPa
       }
       else
       {
-        DEBUG_WM(F("Failed to connect"));
+          if(_tryConnectDuringConfigPortal)
+            DEBUG_WM(F("Failed to connect"));
       }
 
       if (_shouldBreakAfterConfig)


### PR DESCRIPTION
This fix is needed when _tryConnectDuringConfigPortal == false. The save button on the wifi scan trigger the connection by placing the connect = true; 

No check is done against _tryConnectDuringConfigPortal is this context.  