### PR TITLE
Fix SSID and Pass not being saved after configPortal

### DIFF
--- a/library.json
+++ b/library.json
@@ -9,5 +9,5 @@
   },
   "frameworks": "arduino",
   "platforms": ["espressif8266", "espressif32"],
-  "version": "0.30"
+  "version": "0.31"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP Async WiFi Manager
-version=0.30
+version=0.31
 author=alanswx
 maintainer=alanswx
 sentence=ESP8266 and ESP32 Async WiFi Connection manager with fallback web configuration portal

--- a/src/ESPAsyncWiFiManager.cpp
+++ b/src/ESPAsyncWiFiManager.cpp
@@ -643,8 +643,10 @@ boolean AsyncWiFiManager::startConfigPortal(char const *apName, char const *apPa
       DEBUG_WM(F("Connecting to new AP"));
 
       // using user-provided _ssid, _pass in place of system-stored ssid and pass
+      WiFi.persistent(true);
       if (_tryConnectDuringConfigPortal and connectWifi(_ssid, _pass) == WL_CONNECTED)
       {
+        WiFi.persistent(false);
         // connected
         WiFi.mode(WIFI_STA);
         // notify that configuration has changed and any optional parameters should be saved


### PR DESCRIPTION
Adding WiFi.persistent(true) and WiFi.persistent(false) as suggested by @BDskii in https://github.com/alanswx/ESPAsyncWiFiManager/issues/102